### PR TITLE
API-130 : source directory is in .dockerignore file. we cannot copy from this directory.

### DIFF
--- a/slate-base.Dockerfile
+++ b/slate-base.Dockerfile
@@ -14,7 +14,6 @@ RUN mkdir /app/slate/source
 
 COPY ./* app/slate/
 COPY ./lib /app/slate/lib
-COPY ./source/searchPage.html /app/slate/source/
 
 WORKDIR /app/slate
 RUN bundle install


### PR DESCRIPTION
However all our commands use source directory as input so everything in it is available in docker container.

Before : 
```
Step 11/13 : COPY ./source/searchPage.html /app/slate/source/
COPY failed: stat /var/lib/docker/tmp/docker-builder009752756/source/searchPage.html: no such file or directory
Sending build context to Docker daemon  935.9kB
Step 1/3 : FROM slate-base
 ---> e124a83145a4
```

now : 
```
Step 11/12 : WORKDIR /app/slate
Removing intermediate container 107f2bcd3ccc
 ---> 03527ef5e3e2
Step 12/12 : RUN bundle install
 ---> Running in 2f6fca1427a2
...
Successfully built 631b5d8a5738
Successfully tagged slate-base:latest
Sending build context to Docker daemon  935.9kB
Step 1/3 : FROM slate-base
 ---> 631b5d8a5738
```