### PR TITLE
Change extraction to use container id instead of static name.

### DIFF
--- a/slate-extract.sh
+++ b/slate-extract.sh
@@ -11,13 +11,14 @@ then
 fi
 
 function slate_build {
-	echo "Remove docker container named 'slate-extract' if present"
-	docker rm --force slate-extract || true
 	echo "Run slate:$SLATE_VERSION with MIDDLEMAN_COMMAND=$1 to extract sources"
-	docker run --env MIDDLEMAN_COMMAND="$1" --name slate-extract docker.appdirect.tools/documentation/slate:${SLATE_VERSION}
-	docker wait slate-extract
+	local CONTAINER_ID="$( docker create --env MIDDLEMAN_COMMAND="$1" docker.appdirect.tools/documentation/slate:${SLATE_VERSION} )"
+	docker start ${CONTAINER_ID}
+	docker wait ${CONTAINER_ID}
 	echo "Copy source to ./build/$2 folder"
-	docker cp slate-extract:/app/slate/build ./build/$2
+	docker cp ${CONTAINER_ID}:/app/slate/build ./build/$2
+	echo "Remove docker container"
+	docker rm --force ${CONTAINER_ID}
 }
 
 echo "Clean Build Folder"


### PR DESCRIPTION
@jlepage-appdirect. Did this change because with static name we can have some problem with jenkins jobs (they delete container of another job, making the last failing)